### PR TITLE
build: allow the factory gov to be transfered

### DIFF
--- a/tests/unit/factory/test_ownership.py
+++ b/tests/unit/factory/test_ownership.py
@@ -1,0 +1,70 @@
+import ape
+from ape import chain, project, reverts
+from utils.constants import ZERO_ADDRESS
+
+
+def test_gov_transfers_ownership(vault_factory, gov, strategist):
+    assert vault_factory.governance() == gov
+    assert vault_factory.pending_governance() == ZERO_ADDRESS
+
+    vault_factory.set_governance(strategist, sender=gov)
+
+    assert vault_factory.governance() == gov
+    assert vault_factory.pending_governance() == strategist
+
+    vault_factory.accept_governance(sender=strategist)
+
+    assert vault_factory.governance() == strategist
+    assert vault_factory.pending_governance() == ZERO_ADDRESS
+
+
+def test_gov_transfers_ownership__gov_cant_accept(vault_factory, gov, strategist):
+    assert vault_factory.governance() == gov
+    assert vault_factory.pending_governance() == ZERO_ADDRESS
+
+    vault_factory.set_governance(strategist, sender=gov)
+
+    assert vault_factory.governance() == gov
+    assert vault_factory.pending_governance() == strategist
+
+    with reverts("not pending governance"):
+        vault_factory.accept_governance(sender=gov)
+
+    assert vault_factory.governance() == gov
+    assert vault_factory.pending_governance() == strategist
+
+
+def test_random_transfers_ownership__fails(vault_factory, gov, strategist):
+    assert vault_factory.governance() == gov
+    assert vault_factory.pending_governance() == ZERO_ADDRESS
+
+    with reverts("not governance"):
+        vault_factory.set_governance(strategist, sender=strategist)
+
+    assert vault_factory.governance() == gov
+    assert vault_factory.pending_governance() == ZERO_ADDRESS
+
+
+def test_gov_transfers_ownership__can_change_pending(
+    vault_factory, gov, bunny, strategist
+):
+    assert vault_factory.governance() == gov
+    assert vault_factory.pending_governance() == ZERO_ADDRESS
+
+    vault_factory.set_governance(strategist, sender=gov)
+
+    assert vault_factory.governance() == gov
+    assert vault_factory.pending_governance() == strategist
+
+    vault_factory.set_governance(bunny, sender=gov)
+
+    assert vault_factory.governance() == gov
+    assert vault_factory.pending_governance() == bunny
+
+    with reverts("not pending governance"):
+        vault_factory.accept_governance(sender=strategist)
+
+    vault_factory.accept_governance(sender=bunny)
+
+    assert vault_factory.governance() == bunny
+    assert vault_factory.pending_governance() == ZERO_ADDRESS


### PR DESCRIPTION
## Description

Changes:
Allow for the governance of the Factory to be able to be changed. 

Reasoning:
1. Otherwise it would have to be deployed by the ychad multisig every time there is a new Vault version wanting to be released.

2. This factory should deploy every vault and last forever. Meaning if at any time the owner was compromised then fees for every vault ever deployed using this factory can now be siphoned off to a incorrect address.


Fixes # (issue)

## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
